### PR TITLE
bump OZ contracts version, fix memory location mismatch

### DIFF
--- a/ape-config.yaml
+++ b/ape-config.yaml
@@ -9,7 +9,7 @@ plugins:
 dependencies:
   - name: openzeppelin
     github: OpenZeppelin/openzeppelin-contracts
-    version: 4.4.2
+    version: 4.7.3
 
 solidity:
   import_remapping:

--- a/ape-config.yaml
+++ b/ape-config.yaml
@@ -13,7 +13,7 @@ dependencies:
 
 solidity:
   import_remapping:
-    - "@openzeppelin=openzeppelin/v4.4.2/contracts"
+    - "@openzeppelin=openzeppelin/v4.7.3/contracts"
 
 contracts_folder: src
 


### PR DESCRIPTION
I got this error when following the README instructions. Looks like a bug in the 4.4.2 Oz contracts release

```
> stderr:
Error: Data locations of parameters have to be the same when overriding non-external functions, but they differ.
   --> governance/Governor.sol:100:5:
    |
100 |     function hashProposal(
    |     ^ (Relevant source part starts here and spans across multiple lines).
Note: Overridden function is here:
  --> governance/IGovernor.sol:92:5:
```

I confirmed the mismatch does exist in that release, see here:

[IGovernor.sol](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v4.4.2/contracts/governance/IGovernor.sol#L92-L97)

[Governor.sol](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v4.4.2/contracts/governance/Governor.sol#L100-L107)

After bumping the version in ape-config.yaml, I was able to build everything and run all tests as expected